### PR TITLE
Replace croniter by cronsim

### DIFF
--- a/custom_components/measureit/config_flow.py
+++ b/custom_components/measureit/config_flow.py
@@ -8,7 +8,6 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
-from croniter import croniter
 from cronsim import CronSim, CronSimError
 from homeassistant.components.sensor.const import (
     CONF_STATE_CLASS,

--- a/custom_components/measureit/config_flow.py
+++ b/custom_components/measureit/config_flow.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from croniter import croniter
+from cronsim import CronSim, CronSimError
 from homeassistant.components.sensor.const import (
     CONF_STATE_CLASS,
     SensorDeviceClass,
@@ -36,6 +37,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowMenuStep,
 )
 from homeassistant.helpers.template import Template
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_CONDITION,
@@ -135,7 +137,11 @@ def validate_period(period: str) -> bool:
     """Validate period input."""
     if period in PREDEFINED_PERIODS:
         return True
-    return croniter.is_valid(period)
+    try:
+        CronSim(period, dt_util.now(dt_util.get_default_time_zone()))
+        return True  # noqa: TRY300
+    except CronSimError:
+        return False
 
 
 async def validate_edit_main_config(

--- a/custom_components/measureit/manifest.json
+++ b/custom_components/measureit/manifest.json
@@ -6,6 +6,5 @@
   "documentation": "https://github.com/danieldotnl/ha-measureit",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/danieldotnl/ha-measureit/issues",
-  "requirements": ["croniter==2.0.2"],
   "version": "0.5.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ colorlog==6.9.0
 pip>=24,<25
 ruff==0.8.5
 pytest-homeassistant-custom-component==0.13.199
-croniter==3.0.3
 pre-commit==4.0.1

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -169,6 +169,7 @@ async def test_time_config_flow(hass: HomeAssistant) -> None:
 
 
 async def test_validate_cron(hass: HomeAssistant) -> None:
+    """Test validate cron in config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -168,6 +168,44 @@ async def test_time_config_flow(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
+async def test_validate_cron(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Choose config for a time config
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "time"}
+    )
+
+    # Fill config name
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_CONFIG_NAME: "test_config_time"}
+    )
+
+    # Fill without valid days
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_CONDITION: "{{ is_state('binary_sensor.test_sensor', 'on') }}",
+            CONF_TW_FROM: "00:00",
+            CONF_TW_TILL: "00:00",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PERIODS: ["123 * * * *"],
+            CONF_UNIT_OF_MEASUREMENT: "s",
+            CONF_DEVICE_CLASS: "duration",
+            CONF_STATE_CLASS: "total_increasing",
+        },
+    )
+
+    assert result["errors"] == {"base": "invalid_cron"}
+
+
 async def test_flow_with_errors(hass: HomeAssistant) -> None:
     """Test flow with input that doesn't validate."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
As croniter is not being maintained any longer, we now use cronsim, which is now also used by HA for the utility_meter integration.