### PR TITLE
Update CI test matrix to Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
     steps:
       - name: Set Timezone
         uses: szenius/set-timezone@v2.0


### PR DESCRIPTION
## Summary
- Update Python version in test workflow from 3.13 to 3.14
- Required because `pytest-homeassistant-custom-component >= 0.13.317` now requires Python >= 3.14, matching upstream Home Assistant core

## Test plan
- [ ] Verify CI tests pass with Python 3.14
- [ ] Confirm PR #260 (renovate dependency update) can be merged after this

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to verify compatibility with Python 3.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->