### PR TITLE
Migrate to StrEnum to fix ruff UP042

### DIFF
--- a/custom_components/measureit/const.py
+++ b/custom_components/measureit/const.py
@@ -1,6 +1,6 @@
 """Constants for MeasureIt."""
 
-from enum import Enum
+from enum import StrEnum
 from logging import Logger, getLogger
 
 LOGGER: Logger = getLogger(__package__)
@@ -58,7 +58,7 @@ PREDEFINED_PERIODS = {
 }
 
 
-class MeterType(str, Enum):
+class MeterType(StrEnum):
     """Enum with possible meter states."""
 
     TIME = "time"
@@ -66,7 +66,7 @@ class MeterType(str, Enum):
     COUNTER = "counter"
 
 
-class SensorState(str, Enum):
+class SensorState(StrEnum):
     """Enum with possible meter states."""
 
     INITIALIZING_SOURCE = "initializing source value"


### PR DESCRIPTION
## Summary
- Replace `class MeterType(str, Enum)` and `class SensorState(str, Enum)` with `StrEnum`
- Fixes the new `UP042` lint rule introduced in ruff 0.15, unblocking PR #256

## Test plan
- [ ] Verify ruff lint check passes
- [ ] Verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code structure with no changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->