### PR TITLE
Remove unused Node.js devcontainer feature

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,9 +3,6 @@
   "image": "mcr.microsoft.com/vscode/devcontainers/python:3.14",
   "postCreateCommand": "scripts/setup && gh auth setup-git",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "24"
-    },
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
   },


### PR DESCRIPTION
## Summary
- Drops `ghcr.io/devcontainers/features/node:1` from [.devcontainer.json](.devcontainer.json).
- This project has no JS/TS sources, no `package.json`, and no scripts (`setup`, `develop`, `lint`) that invoke `node`/`npm`. The feature existed only to back the `claude-code` feature, which auto-installs Node 18 from NodeSource when it isn't already present (see its [install.sh](https://github.com/anthropics/devcontainer-features/blob/main/src/claude-code/install.sh)).
- Makes #271 (Renovate node feature bump) obsolete — closing that in favour of this.

## Test plan
- [ ] Rebuild the devcontainer from scratch and confirm it comes up cleanly.
- [ ] Verify `claude --version` works inside the rebuilt container (claude-code feature installs its own Node).
- [ ] Confirm `scripts/setup`, `scripts/develop`, and `scripts/lint` still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to streamline feature management and improve consistency in the development setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->